### PR TITLE
Minor typo fix in `tutorial.ipynb`

### DIFF
--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -1488,7 +1488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll add information to describe the stimulus, including waveform shape and and stimulation parameters."
+    "We'll add information to describe the stimulus, including waveform shape and stimulation parameters."
    ]
   },
   {

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The table classes in the module corresponds to a table in the database."
+    "The table classes in the module correspond to a table in the database."
    ]
   },
   {


### PR DESCRIPTION
Just found a small typo in my second read-through before we merge into `datajoint/main`